### PR TITLE
Allow Font Size in Pixels or Points

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
 		<title>A tiny, opensource, Bootstrap WYSIWYG rich text editor</title>
 		<meta name="keywords" content="opensource rich wysiwyg text editor jquery bootstrap execCommand html5" />
 		<meta name="description" content="This tiny jQuery Bootstrap WYSIWYG plugin turns any DIV into a HTML5 rich text editor" />
-		<link href="bower_components/google-code-prettify/src/prettify.css" rel="stylesheet" />
 		<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" />
 		<link href="http://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css" rel="stylesheet" />
 		<link href="css/style.css" rel="stylesheet" />
@@ -42,6 +41,28 @@
 							<li><a data-edit="fontSize 1" class="fs-One">Small</a></li>
 						</ul>
 					</div>
+					<div class="btn-group">
+						<a class="btn btn-default dropdown-toggle" data-toggle="dropdown"
+							title="Font Size Px"><i class="fa fa-text-height"></i>&nbsp;<b
+							class="caret"></b>
+						</a>
+						<ul class="dropdown-menu">
+							<li><a data-edit="fontPixel 15" class="fs-Five">15px</a></li>
+							<li><a data-edit="fontPixel 10" class="fs-Three">10px</a></li>
+							<li><a data-edit="fontPixel 5" class="fs-One">5px</a></li>
+						</ul>
+					</div>
+					<div class="btn-group">
+						<a class="btn btn-default dropdown-toggle" data-toggle="dropdown"
+							title="Font Size Pt"><i class="fa fa-text-height"></i>&nbsp;<b
+							class="caret"></b>
+						</a>
+						<ul class="dropdown-menu">
+							<li><a data-edit="fontPoint 15" class="fs-Five">15pt</a></li>
+							<li><a data-edit="fontPoint 10" class="fs-Three">10pt</a></li>
+							<li><a data-edit="fontPoint 5" class="fs-One">5pt</a></li>
+						</ul>
+					</div>				
 					<div class="btn-group">
 						<a class="btn btn-default" data-edit="bold" title="Bold (Ctrl/Cmd+B)"><i class="fa fa-bold"></i></a>
 						<a class="btn btn-default" data-edit="italic" title="Italic (Ctrl/Cmd+I)"><i class="fa fa-italic"></i></a>
@@ -165,9 +186,9 @@
 		</a>
 
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-		<script src="bower_components/jquery.hotkeys/jquery.hotkeys.js"></script>
+		<script src="https://cdn.rawgit.com/jeresig/jquery.hotkeys/f24f1da2/jquery.hotkeys.js"></script>
 		<script src="http://netdna.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
-		<script src="bower_components/google-code-prettify/src/prettify.js"></script>
+		<script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
 		<script src="src/bootstrap-wysiwyg.js"></script>
 		<script>
 			$(function()

--- a/src/bootstrap-wysiwyg.js
+++ b/src/bootstrap-wysiwyg.js
@@ -240,12 +240,12 @@
         }
      };
 
-     Wysiwyg.prototype.insertFontPoint = function ( value, editor, options, toolbarBtnSelector ) {
+     Wysiwyg.prototype.insertFontSize = function ( value, type, editor, options, toolbarBtnSelector ) {
         var self = this;
         editor.focus();
 
         self.execCommand( 'fontSize 7', null, editor, options, toolbarBtnSelector );
-        editor.find( 'font[size="7"]' ).removeAttr( 'size' ).css( 'font-size', value + 'pt' );
+        editor.find( 'font[size="7"]' ).removeAttr( 'size' ).css( 'font-size', value + ( type === 'pt' ? 'pt' : 'px' ) );
     };
 
     Wysiwyg.prototype.insertHTML = function ( html, editor ) {
@@ -378,13 +378,20 @@
 
             if ( $( this ).data( options.commandRole ) === "html" ) {
                 self.toggleHtmlEdit( editor );
+            } else if ( $( this ).data( options.commandRole ).indexOf( 'fontPixel' ) >= 0 ) {
+                var commandArr = $( this ).data( options.commandRole ).split( ' ' );
+                commandArr.shift();
+                var args = commandArr.join( ' ' ) + ( '' );
+
+                self.insertFontSize( args, "px", editor, options, toolbarBtnSelector );
             } else if ( $( this ).data( options.commandRole ).indexOf( 'fontPoint' ) >= 0 ) {
                 var commandArr = $( this ).data( options.commandRole ).split( ' ' );
                 commandArr.shift();
                 var args = commandArr.join( ' ' ) + ( '' );
 
-                self.insertFontPoint( args, editor, options, toolbarBtnSelector );
-            } else {
+                self.insertFontSize( args, "pt", editor, options, toolbarBtnSelector );
+            }
+            else {
                 self.execCommand( $( this ).data( options.commandRole ), null, editor, options, toolbarBtnSelector );
             }
 


### PR DESCRIPTION
Allow users to specify font size in either pixels or points in addition
to the existing "font size". Removed bower link to Prettify. Added
buttons to index.html toolbar to showcase/test font size in pixels and
in points.